### PR TITLE
define global assignments

### DIFF
--- a/_sass/foundation-sites/scss/util/_breakpoint.scss
+++ b/_sass/foundation-sites/scss/util/_breakpoint.scss
@@ -2,6 +2,8 @@
 // https://get.foundation
 // Licensed under MIT Open Source
 
+$-zf-size: null;
+
 ////
 /// @group breakpoints
 ////

--- a/_sass/foundation-sites/scss/util/_color.scss
+++ b/_sass/foundation-sites/scss/util/_color.scss
@@ -5,6 +5,11 @@
 @import 'math';
 
 $contrast-warnings: true !default;
+$primary-color: null;
+$secondary-color: null;
+$success-color: null;
+$warning-color: null;
+$alert-color: null;
 
 ////
 /// @group functions

--- a/_sass/foundation-sites/scss/util/_mixins.scss
+++ b/_sass/foundation-sites/scss/util/_mixins.scss
@@ -2,6 +2,8 @@
 // https://get.foundation
 // Licensed under MIT Open Source
 
+$-zf-bp-value: null;
+
 ////
 /// @group functions
 ////


### PR DESCRIPTION
fixes warnings on libsass 3.6.4
<pre>
DEPRECATION WARNING on line 369 of /riverscapes-jekyll-theme/_sass/foundation-sites/scss/util/_mixins.scss:
!global assignments won't be able to declare new variables in future versions.
Consider adding `$-zf-bp-value: null` at the top level.
</pre>